### PR TITLE
Add delete prompt route

### DIFF
--- a/src/routes/prompt.routes.js
+++ b/src/routes/prompt.routes.js
@@ -19,4 +19,8 @@ router.get('/:id', c.get);
 // PUT /prompts/:id
 router.put('/:id', c.update);
 
+// Remove a Prompt by its ID
+// DELETE /prompts/:id
+router.delete('/:id', c.remove);
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- register DELETE route for prompts

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6879800eb8e083269bc427c79d58d508