### PR TITLE
Add Jest and integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node src/app.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -19,6 +19,9 @@
   },
   "devDependencies": {
     "nodemon": "^3.1.10",
-    "sequelize-cli": "^6.6.3"
+    "sequelize-cli": "^6.6.3",
+    "jest": "^29.6.0",
+    "supertest": "^6.3.4",
+    "sqlite3": "^5.1.6"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -10,9 +10,15 @@ app.use(express.json());
 app.use('/prompts', promptRoutes);
 app.use(notFound);
 
-(async () => {
+const start = async () => {
   await sequelize.authenticate();
-  await sequelize.sync();      
+  await sequelize.sync();
   const PORT = process.env.PORT || 3000;
-  app.listen(PORT, () => console.log(`API running at http://localhost:${PORT}`));
-})();
+  return app.listen(PORT, () => console.log(`API running at http://localhost:${PORT}`));
+};
+
+if (require.main === module) {
+  start();
+}
+
+module.exports = { app, start };

--- a/tests/prompt.test.js
+++ b/tests/prompt.test.js
@@ -1,0 +1,35 @@
+const request = require('supertest');
+process.env.DB_URL = 'sqlite::memory:';
+
+const { app } = require('../src/app');
+const sequelize = require('../src/config/database');
+
+beforeAll(async () => {
+  await sequelize.authenticate();
+  await sequelize.sync();
+});
+
+afterAll(async () => {
+  await sequelize.close();
+});
+
+describe('Prompt API', () => {
+  it('creates and retrieves a prompt', async () => {
+    const createRes = await request(app)
+      .post('/prompts')
+      .send({ title: 'Hello', body: 'World', tags: ['tag1', 'tag2'] })
+      .expect(201);
+
+    const { id } = createRes.body;
+
+    const getRes = await request(app).get(`/prompts/${id}`).expect(200);
+    expect(getRes.body).toEqual(
+      expect.objectContaining({
+        id,
+        title: 'Hello',
+        body: 'World',
+        tags: 'tag1,tag2',
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest, Supertest, and sqlite3 dev deps
- export the Express app and startup method
- create prompt API test
- set test script to run Jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879862088d083269248094eacbe7273