### PR TITLE
Add Tag and PromptTag models

### DIFF
--- a/src/models/prompt.model.js
+++ b/src/models/prompt.model.js
@@ -1,13 +1,16 @@
 const { DataTypes } = require('sequelize');
 const sequelize = require('../config/database');
+const Tag = require('./tag.model');
 
 const Prompt = sequelize.define('Prompt', {
-  title:      { type: DataTypes.STRING(120), allowNull: false },
-  body:       { type: DataTypes.TEXT,        allowNull: false },
-  tags:       { type: DataTypes.STRING(255), allowNull: true },
+  title: { type: DataTypes.STRING(120), allowNull: false },
+  body:  { type: DataTypes.TEXT,        allowNull: false },
 }, {
   tableName: 'prompts',
   underscored: true,          // created_at, updated_at
 });
+
+Prompt.belongsToMany(Tag, { through: 'prompt_tags', as: 'tags' });
+Tag.belongsToMany(Prompt, { through: 'prompt_tags', as: 'prompts' });
 
 module.exports = Prompt;

--- a/src/models/tag.model.js
+++ b/src/models/tag.model.js
@@ -1,0 +1,12 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/database');
+
+const Tag = sequelize.define('Tag', {
+  name:     { type: DataTypes.STRING(50), allowNull: false },
+  category: { type: DataTypes.STRING(50), allowNull: false },
+}, {
+  tableName: 'tags',
+  underscored: true,
+});
+
+module.exports = Tag;

--- a/src/services/prompt.service.js
+++ b/src/services/prompt.service.js
@@ -1,17 +1,55 @@
 const Prompt = require('../models/prompt.model');
+const Tag = require('../models/tag.model');
 
-exports.create = (data) => Prompt.create({ ...data, tags: data.tags?.join(',') });
+const includeTags = { model: Tag, as: 'tags', through: { attributes: [] } };
 
-exports.getById = (id) => Prompt.findByPk(id);
+exports.create = async (data) => {
+  const { tags = [], ...promptData } = data;
+  const prompt = await Prompt.create(promptData);
+  if (tags.length) {
+    const tagInstances = [];
+    for (const t of tags) {
+      let tag;
+      if (typeof t === 'string') {
+        [tag] = await Tag.findOrCreate({ where: { name: t, category: 'general' } });
+      } else {
+        [tag] = await Tag.findOrCreate({
+          where: { name: t.name, category: t.category || 'general' },
+        });
+      }
+      tagInstances.push(tag);
+    }
+    await prompt.addTags(tagInstances);
+  }
+  return exports.getById(prompt.id);
+};
+
+exports.getById = (id) => Prompt.findByPk(id, { include: includeTags });
 
 exports.list = (offset = 0, limit = 20) =>
-  Prompt.findAll({ offset, limit, order: [['created_at', 'DESC']] });
+  Prompt.findAll({ offset, limit, order: [['created_at', 'DESC']], include: includeTags });
 
 exports.update = async (id, data) => {
   const prompt = await Prompt.findByPk(id);
   if (!prompt) return null;
-  await prompt.update({ ...data, tags: data.tags?.join(',') });
-  return prompt;
+  const { tags, ...promptData } = data;
+  await prompt.update(promptData);
+  if (tags) {
+    const tagInstances = [];
+    for (const t of tags) {
+      let tag;
+      if (typeof t === 'string') {
+        [tag] = await Tag.findOrCreate({ where: { name: t, category: 'general' } });
+      } else {
+        [tag] = await Tag.findOrCreate({
+          where: { name: t.name, category: t.category || 'general' },
+        });
+      }
+      tagInstances.push(tag);
+    }
+    await prompt.setTags(tagInstances);
+  }
+  return exports.getById(id);
 };
 
 exports.remove = (id) => Prompt.destroy({ where: { id } });

--- a/tests/prompt.test.js
+++ b/tests/prompt.test.js
@@ -14,22 +14,31 @@ afterAll(async () => {
 });
 
 describe('Prompt API', () => {
-  it('creates and retrieves a prompt', async () => {
+  it('creates and retrieves a prompt with tags', async () => {
+    const tags = [
+      { name: 'tag1', category: 'model' },
+      { name: 'tag2', category: 'task' },
+    ];
     const createRes = await request(app)
       .post('/prompts')
-      .send({ title: 'Hello', body: 'World', tags: ['tag1', 'tag2'] })
+      .send({ title: 'Hello', body: 'World', tags })
       .expect(201);
 
     const { id } = createRes.body;
 
+    expect(createRes.body.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(tags[0]),
+        expect.objectContaining(tags[1]),
+      ])
+    );
+
     const getRes = await request(app).get(`/prompts/${id}`).expect(200);
-    expect(getRes.body).toEqual(
-      expect.objectContaining({
-        id,
-        title: 'Hello',
-        body: 'World',
-        tags: 'tag1,tag2',
-      })
+    expect(getRes.body.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(tags[0]),
+        expect.objectContaining(tags[1]),
+      ])
     );
   });
 });


### PR DESCRIPTION
## Summary
- add `Tag` model with `category`
- create many-to-many association between `Prompt` and `Tag`
- update prompt service to handle tags through association
- update tests for new tag structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d5bffd2f083268ba43d8bf441bfab