### PR TITLE
Add prompt statistics model and interaction endpoints

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 require('dotenv').config();
 const sequelize = require('./config/database');
 require('./models/promptVersion.model');
+require('./models/promptStat.model');
 const promptRoutes = require('./routes/prompt.routes');
 const migrateRoutes = require('./routes/migrate.routes');
 const notFound = require('./middlewares/notFound');

--- a/src/controllers/prompt.controller.js
+++ b/src/controllers/prompt.controller.js
@@ -9,8 +9,8 @@ exports.create = async (req, res, next) => {
 
 exports.list = async (req, res, next) => {
   try {
-    const { page = 1, size = 20 } = req.query;
-    const prompts = await service.list((page - 1) * size, +size);
+    const { page = 1, size = 20, sort = 'hot' } = req.query;
+    const prompts = await service.list((page - 1) * size, +size, sort);
     res.json(prompts);
   } catch (e) { next(e); }
 };
@@ -36,6 +36,30 @@ exports.remove = async (req, res, next) => {
     const rows = await service.remove(req.params.id);
     if (!rows) return res.status(404).send('Not Found');
     res.status(204).end();
+  } catch (e) { next(e); }
+};
+
+exports.like = async (req, res, next) => {
+  try {
+    const prompt = await service.addLike(req.params.id);
+    if (!prompt) return res.status(404).send('Not Found');
+    res.status(200).json(prompt);
+  } catch (e) { next(e); }
+};
+
+exports.use = async (req, res, next) => {
+  try {
+    const prompt = await service.addUse(req.params.id);
+    if (!prompt) return res.status(404).send('Not Found');
+    res.status(200).json(prompt);
+  } catch (e) { next(e); }
+};
+
+exports.rating = async (req, res, next) => {
+  try {
+    const prompt = await service.addRating(req.params.id, req.body.score);
+    if (!prompt) return res.status(404).send('Not Found');
+    res.status(200).json(prompt);
   } catch (e) { next(e); }
 };
 

--- a/src/models/promptStat.model.js
+++ b/src/models/promptStat.model.js
@@ -1,0 +1,23 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/database');
+const Prompt = require('./prompt.model');
+
+/**
+ * 统计数据：每条 Prompt 一行
+ * likes、uses 为累积计数；rating_sum/rating_count 用于求平均分。
+ */
+const PromptStat = sequelize.define('PromptStat', {
+  prompt_id:   { type: DataTypes.INTEGER, allowNull: false, unique: true },
+  likes:       { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  uses:        { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  rating_sum:  { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  rating_count:{ type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+}, {
+  tableName: 'prompt_stats',
+  underscored: true,
+});
+
+PromptStat.belongsTo(Prompt, { foreignKey: 'prompt_id' });
+Prompt.hasOne(PromptStat, { foreignKey: 'prompt_id', as: 'stat' });
+
+module.exports = PromptStat;

--- a/src/routes/migrate.routes.js
+++ b/src/routes/migrate.routes.js
@@ -3,6 +3,7 @@ const sequelize = require('../config/database');
 require('../models/prompt.model');
 require('../models/tag.model');
 require('../models/promptVersion.model');
+require('../models/promptStat.model');
 
 const router = Router();
 

--- a/src/routes/prompt.routes.js
+++ b/src/routes/prompt.routes.js
@@ -19,6 +19,14 @@ router.get('/:id', c.get);
 // PUT /prompts/:id
 router.put('/:id', c.update);
 
+// --- Stats APIs ---
+// POST /prompts/:id/like
+router.post('/:id/like', c.like);
+// POST /prompts/:id/use
+router.post('/:id/use', c.use);
+// POST /prompts/:id/rating  { score: 1..5 }
+router.post('/:id/rating', c.rating);
+
 // List versions
 router.get('/:id/versions', c.listVersions);
 


### PR DESCRIPTION
## Summary
- add `PromptStat` model to track likes, uses, and ratings
- expose endpoints for liking, using, and rating prompts
- allow listing prompts sorted by popularity or rating

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68980759778c83269019ee5db1858066